### PR TITLE
Bump uber so it works on Ruby 2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uber (0.0.11)
+    uber (0.0.13)
     uglifier (2.6.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)


### PR DESCRIPTION
After bundling on Ruby 2.2.1 trying to run `middleman`bombed out with an `undefined method ‘each’ for nil:NilClass (NoMethodError)` error on line 26 of uber’s `lib/uber/inheritable_attr.rb`. Bumping uber made the problem go away.
