### PR TITLE
Centre the header image

### DIFF
--- a/source/stylesheets/modules/_header.scss
+++ b/source/stylesheets/modules/_header.scss
@@ -6,6 +6,11 @@ header {
   overflow: hidden;
 }
 
+.header-image {
+  display: block;
+  margin: auto;
+}
+
 .header-logo {
   width: 430px;
   margin-bottom: $header-margin;


### PR DESCRIPTION
This centres the header image, so instead of this:

![off](https://cloud.githubusercontent.com/assets/56633/6698875/248b4b90-ccfd-11e4-9e64-8a55cab005b8.png)

the page shows like this:

![centred](https://cloud.githubusercontent.com/assets/56633/6698880/2e7e6fc4-ccfd-11e4-9f5e-951e95eda7f2.png)
