### PR TITLE
Proper ‘ROSSConf’ capitalisation in the site’s <title>

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,5 +1,5 @@
 ---
-title: rossconf
+title: ROSSConf
 ---
 <header>
   <%= image_tag "header-bg.jpg", class: "header-image", alt: 'Ruby Open Source Software Conference Vienna' %>


### PR DESCRIPTION
Whenever I want to check how something is _exactly_ spelt/capitalised I check the `<title>` tag of its site, as it has to contain a no-fluff, text version of the spelling.

This makes the website’s `<title>` tag actually capitalise ‘ROSSConf’ properly. ;)
