### PR TITLE
Fix date typo for remote RossConf

### DIFF
--- a/data/events/remote.yml
+++ b/data/events/remote.yml
@@ -3,8 +3,8 @@ slug: CEST remote friendly
 header: /images/eventheader/amsterdam.jpg
 header_front: /images/eventheader/amsterdam.jpg
 tagline: The European Remote Only Ruby Open Source Software conference
-date_location: October 26, 2020 - channels to be decided
-date: 26-10-2020
+date_location: Friday October 23, 2020 - channels to be decided
+date: 23-10-2020
 description: '<p>ROSS conf gives open source software maintainers the platform to introduce their project to an audience of first time as well as existing contributors. After introductions to the project, pressing issues and requests, the conference day is reserved for hands-on programming (or contributing through updating documentation or adding artwork!) and pairing with the maintainers. To conclude the hackathon the maintainers present data on bugs fixed, and pull requests merged.</p>'
 sponsoring_email: 'hello@rossconf.io'
 eventbrite_link: ''


### PR DESCRIPTION
Or is that RossrConf, short for Ruby Open source _R_emote Conference?