### PR TITLE
Make CoC people email address clickable

### DIFF
--- a/docs/blog/2015-07/kickoff/index.html
+++ b/docs/blog/2015-07/kickoff/index.html
@@ -112,7 +112,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/blog/2015-08/meet-our-speakers-andre/index.html
+++ b/docs/blog/2015-08/meet-our-speakers-andre/index.html
@@ -100,7 +100,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/blog/2015-08/meet-our-speakers-laura/index.html
+++ b/docs/blog/2015-08/meet-our-speakers-laura/index.html
@@ -100,7 +100,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/blog/2015-08/meet-our-speakers-piotr/index.html
+++ b/docs/blog/2015-08/meet-our-speakers-piotr/index.html
@@ -100,7 +100,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/blog/2015-09/meet-our-speakers-tyranja/index.html
+++ b/docs/blog/2015-09/meet-our-speakers-tyranja/index.html
@@ -100,7 +100,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/blog/2015-09/meet-our-speakers-zachary/index.html
+++ b/docs/blog/2015-09/meet-our-speakers-zachary/index.html
@@ -113,7 +113,7 @@ implementation that's still Just Ruby.</p>
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/blog/2015-10/rossconf-berlin/index.html
+++ b/docs/blog/2015-10/rossconf-berlin/index.html
@@ -143,7 +143,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -115,7 +115,7 @@ who is and has committed to Sinatra, mruby, rails and, the project he will prese
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/event/amsterdam/index.html
+++ b/docs/event/amsterdam/index.html
@@ -302,7 +302,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/event/berlin/index.html
+++ b/docs/event/berlin/index.html
@@ -351,7 +351,7 @@ Sign up via <a href="https://rubyissues.ongoodbits.com/">rubyissues.ongoodbits.c
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/event/remote/index.html
+++ b/docs/event/remote/index.html
@@ -204,9 +204,9 @@
             <a href='https://youtu.be/p3IXtkxNPms'>Closing notes and maintainer updates (8PM)</a>
           </div>
         <br>
-        <div>Don't be late</div>
+        <div>Be there or be square</div>
         <div>
-          Add the event to your calendar and visit this page when the event starts.
+          Add the event to your calendar and visit this page when the event starts. <a href:"https://discord.gg/HKUh4jn" target="_blank">Open our Discord server to join the AMAs</a>. 
           <br>
           <a href="https://everytimezone.com/s/458a8d7d" class="button">＋ Add to calendar</a>
         </div>
@@ -295,7 +295,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/event/vienna/index.html
+++ b/docs/event/vienna/index.html
@@ -484,7 +484,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -127,7 +127,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/partials/head/index.html
+++ b/docs/partials/head/index.html
@@ -63,7 +63,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/docs/partials/header/index.html
+++ b/docs/partials/header/index.html
@@ -61,7 +61,7 @@
     <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>

--- a/source/partials/_footer.html.erb
+++ b/source/partials/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer id="footer">
   <div class="container">
     <p>
-      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), rayta@rubynl.org, or Tom de Bruijn (he/him), tom@rubynl.org.
+      The ROSS conf project and event adheres to the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/" target="_blank">Contributor Convenant Code of Conduct</a>. By participating, you are expected to honor this code. If you notice or experience anything that's not in line with our CoC, please reach out to our team: Rayta van Rijswijk (she/her), <a href="mailto:rayta@rubynl.org">rayta@rubynl.org</a>, or Tom de Bruijn (he/him), <a href="mailto:tom@rubynl.org">tom@rubynl.org</a>.
     </p>
     <hr />
     Get in touch with ROSS conf via <a href="mailto:hello@rossconf.io">hello@rossconf.io</a>


### PR DESCRIPTION
Rebuild the site and checking in the build artefacts as seems to have
been done so far, but it's also updating all the other events we're not
CoC team for?